### PR TITLE
data-parser/storage: deprecate session.New() for session.NewSession()

### DIFF
--- a/data-parser/storage/file_system.go
+++ b/data-parser/storage/file_system.go
@@ -23,7 +23,10 @@ var (
 
 func init() {
 	// TODO: could the regsion set from environment variable?
-	sess := session.New(&aws.Config{Region: aws.String(endpoints.ApNortheast1RegionID)})
+	sess, err := session.NewSession(&aws.Config{Region: aws.String(endpoints.ApNortheast1RegionID)})
+	if err != nil {
+		panic(err)
+	}
 	uploader = s3manager.NewUploader(sess)
 	downloader = s3manager.NewDownloader(sess)
 }


### PR DESCRIPTION
The AWS `session` package has deprecated `New()` and replaced it with `NewSession()`, which is functionally the same, but with an error variable returned.

Since this code is using `session.New()` in an `init()`, the best thing to do with this error variable is to panic.